### PR TITLE
Abstract Creation of Two Pages and Add Widgets

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,9 @@
 // ignore_for_file: prefer_const_constructors
 import 'package:flutter/material.dart';
 import 'package:to_dont_list/event_items.dart';
-import 'package:to_dont_list/to_do_items.dart';
+
+// unneeded import
+// import 'package:to_dont_list/to_do_items.dart';
 
 List<Event> sprints = [
   Event(event: "400M", mark: "49.03", year: "2022", meet: "UCA")
@@ -33,7 +35,7 @@ class _TrackListState extends State<TrackList> {
         return AlertDialog(
           title: Text('Add Event'),
           content: SingleChildScrollView(
-            child: Container(
+            child: SizedBox(
               height: 200,
               width: 200,
               child: Column(
@@ -86,8 +88,8 @@ class _TrackListState extends State<TrackList> {
 
   void _handleTrackItem(event, mark, year, meet) {
     setState(() {
-      Event _event = Event(event: event, mark: mark, year: year, meet: meet);
-      sprints.insert(0, _event);
+      Event newEvent = Event(event: event, mark: mark, year: year, meet: meet);
+      sprints.insert(0, newEvent);
       eventController.clear();
       markController.clear();
       yearController.clear();
@@ -301,6 +303,29 @@ class _TrackListState extends State<TrackList> {
 //             }));
 //   }
 // }
+
+// widget for listing the events as a List Tile within navigator
+class ListEvents extends StatelessWidget {
+  const ListEvents({Key? key, required this.title}) : super(key: key);
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) {
+              return TrackList(title: title);
+            },
+          ),
+        );
+      },
+    );
+  }
+}
 
 void main() {
   runApp(const MaterialApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:to_dont_list/event_items.dart';
 List<Event> sprints = [
   Event(event: "400M", mark: "49.03", year: "2022", meet: "UCA")
 ];
-List<Event> distance = [
+List<Event> distances = [
   Event(event: "1600M", mark: "5:00", year: "2019", meet: "Arkansas State")
 ];
 
@@ -86,78 +86,106 @@ class _TrackListState extends State<TrackList> {
     );
   }
 
-  void _handleTrackItem(event, mark, year, meet) {
-    setState(() {
-      Event newEvent = Event(event: event, mark: mark, year: year, meet: meet);
-      sprints.insert(0, newEvent);
-      eventController.clear();
-      markController.clear();
-      yearController.clear();
-      meetController.clear();
-    });
+  // get the current title of the widget
+  String getTitle() {
+    return widget.title;
   }
 
+  void _handleTrackItem(event, mark, year, meet) {
+    setState(
+      () {
+        // renamed to newEvent to make clearer
+        Event newEvent =
+            Event(event: event, mark: mark, year: year, meet: meet);
+        if (getTitle() == 'Sprints') {
+          sprints.insert(0, newEvent);
+        } else {
+          distances.insert(0, newEvent);
+        }
+        eventController.clear();
+        markController.clear();
+        yearController.clear();
+        meetController.clear();
+      },
+    );
+  }
+
+  // tap on event to delete
   void _handleEventEdit(Event event) {
-    setState(() {
-      sprints.remove(event);
-      _EventInfoPopupForm(context);
-    });
+    setState(
+      () {
+        // if sprints then remove sprint event
+        if (getTitle() == 'Sprints') {
+          sprints.remove(event);
+        }
+        // else remove distance
+        else {
+          distances.remove(event);
+        }
+        // commented out given it shows a deleted event
+        // _EventInfoPopupForm(context);
+      },
+    );
   }
 
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Sprint Personal Records'),
-        ),
-        // drawer code from https://rushabhshah065.medium.com/flutter-navigation-drawer-tab-layout-e74074c249ce
-        drawer: Drawer(
-          child: ListView(
-            children: [
-              DrawerHeader(
-                decoration: BoxDecoration(color: Colors.green),
-                child: Text(
-                  "Type of Event",
-                  textAlign: TextAlign.justify,
-                  textScaleFactor: 2.0,
-                ),
+      appBar: AppBar(
+        // determine title based on widget title parameter
+        title: Text(getTitle() == 'Sprints'
+            ? "Sprint Personal Records"
+            : "Distance Personal Records"),
+      ),
+      // drawer code from https://rushabhshah065.medium.com/flutter-navigation-drawer-tab-layout-e74074c249ce
+      drawer: Drawer(
+        child: ListView(
+          children: const [
+            DrawerHeader(
+              decoration: BoxDecoration(color: Colors.green),
+              child: Text(
+                "Type of Event",
+                textAlign: TextAlign.justify,
+                textScaleFactor: 2.0,
               ),
-              ListTile(
-                  title: Text("Sprints"),
-                  onTap: () {
-                    Navigator.push(context,
-                        MaterialPageRoute(builder: (context) {
-                      return const TrackList(title: 'Sprints');
-                    }));
-                  }),
-              ListTile(
-                title: Text("Distance"),
-                onTap: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return const TrackList(title: 'Distance');
-                  }));
+            ),
+            // call ListEvents Stateless widget to give list tile for navigation
+            ListEvents(title: 'Sprints'),
+            ListEvents(title: 'Distance'),
+          ],
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        // set children as either sprints or distances depending on title
+        children: getTitle() == 'Sprints'
+            ? sprints.map(
+                (item) {
+                  return EventItem(
+                    event: item,
+                    eventEdit: _handleEventEdit,
+                  );
                 },
-              ),
-            ],
-          ),
-        ),
-        body: ListView(
-          padding: const EdgeInsets.symmetric(vertical: 8.0),
-          children: sprints.map((item) {
-            return EventItem(
-              event: item,
-              eventEdit: _handleEventEdit,
-            );
-          }).toList(),
-        ),
-        floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.add),
-            onPressed: () {
-              _EventInfoPopupForm(context);
-            }));
+              ).toList()
+            : distances.map(
+                (item) {
+                  return EventItem(
+                    event: item,
+                    eventEdit: _handleEventEdit,
+                  );
+                },
+              ).toList(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.add),
+        onPressed: () {
+          _EventInfoPopupForm(context);
+        },
+      ),
+    );
   }
 }
 
-// UNNEEDED CLASS (BOTH PAGES CALL TRACKLIST CLASS)
+// UNNEEDED SECOND PAGE CODE (APP ONLY USES TRACKLIST STATEFUL WIDGET NOW)
 
 // class SecondPage extends StatefulWidget {
 //   const SecondPage({key, required this.title}) : super(key: key);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,7 +131,7 @@ class _TrackListState extends State<TrackList> {
                 title: Text("Distance"),
                 onTap: () {
                   Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return const SecondPage(title: 'Distance');
+                    return const TrackList(title: 'Distance');
                   }));
                 },
               ),
@@ -155,150 +155,152 @@ class _TrackListState extends State<TrackList> {
   }
 }
 
-class SecondPage extends StatefulWidget {
-  const SecondPage({key, required this.title}) : super(key: key);
-  @override
-  State createState() => _SecondPageState();
-  final String title;
-}
+// UNNEEDED CLASS (BOTH PAGES CALL TRACKLIST CLASS)
 
-class _SecondPageState extends State<SecondPage> {
-  var eventController = TextEditingController();
-  var markController = TextEditingController();
-  var yearController = TextEditingController();
-  var meetController = TextEditingController();
-  //Form code comes from https://stackoverflow.com/questions/54480641/flutter-how-to-create-forms-in-popup
-  // ignore: non_constant_identifier_names
-  Future<void> _EventInfoPopupForm(BuildContext context) async {
-    return showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text('Add Event'),
-          content: SingleChildScrollView(
-            child: Container(
-              height: 200,
-              width: 200,
-              child: Column(
-                children: [
-                  TextFormField(
-                    controller: eventController,
-                    decoration: InputDecoration(hintText: 'Event'),
-                  ),
-                  TextFormField(
-                    controller: markController,
-                    decoration: InputDecoration(hintText: 'Mark'),
-                  ),
-                  TextFormField(
-                    controller: yearController,
-                    decoration: InputDecoration(hintText: 'Year'),
-                  ),
-                  TextFormField(
-                    controller: meetController,
-                    decoration: InputDecoration(hintText: 'Meet'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () {
-                setState(() {
-                  _handleTrackItem(eventController.text, markController.text,
-                      yearController.text, meetController.text);
-                  Navigator.pop(context);
-                });
-              },
-              child: Text('Send'),
-            ),
-          ],
-        );
-      },
-    );
-  }
+// class SecondPage extends StatefulWidget {
+//   const SecondPage({key, required this.title}) : super(key: key);
+//   @override
+//   State createState() => _SecondPageState();
+//   final String title;
+// }
 
-  String valueText = "";
+// class _SecondPageState extends State<SecondPage> {
+//   var eventController = TextEditingController();
+//   var markController = TextEditingController();
+//   var yearController = TextEditingController();
+//   var meetController = TextEditingController();
+//   //Form code comes from https://stackoverflow.com/questions/54480641/flutter-how-to-create-forms-in-popup
+//   // ignore: non_constant_identifier_names
+//   Future<void> _EventInfoPopupForm(BuildContext context) async {
+//     return showDialog(
+//       context: context,
+//       builder: (context) {
+//         return AlertDialog(
+//           title: Text('Add Event'),
+//           content: SingleChildScrollView(
+//             child: Container(
+//               height: 200,
+//               width: 200,
+//               child: Column(
+//                 children: [
+//                   TextFormField(
+//                     controller: eventController,
+//                     decoration: InputDecoration(hintText: 'Event'),
+//                   ),
+//                   TextFormField(
+//                     controller: markController,
+//                     decoration: InputDecoration(hintText: 'Mark'),
+//                   ),
+//                   TextFormField(
+//                     controller: yearController,
+//                     decoration: InputDecoration(hintText: 'Year'),
+//                   ),
+//                   TextFormField(
+//                     controller: meetController,
+//                     decoration: InputDecoration(hintText: 'Meet'),
+//                   ),
+//                 ],
+//               ),
+//             ),
+//           ),
+//           actions: <Widget>[
+//             TextButton(
+//               onPressed: () => Navigator.pop(context),
+//               child: Text('Cancel'),
+//             ),
+//             TextButton(
+//               onPressed: () {
+//                 setState(() {
+//                   _handleTrackItem(eventController.text, markController.text,
+//                       yearController.text, meetController.text);
+//                   Navigator.pop(context);
+//                 });
+//               },
+//               child: Text('Send'),
+//             ),
+//           ],
+//         );
+//       },
+//     );
+//   }
 
-  //final List<Item> items = [const Item(name: "Add homework")];
+//   String valueText = "";
 
-  final _itemSet = <Item>{};
+//   //final List<Item> items = [const Item(name: "Add homework")];
 
-  void _handleTrackItem(event, mark, year, meet) {
-    setState(() {
-      Event _event = Event(event: event, mark: mark, year: year, meet: meet);
-      sprints.insert(0, _event);
-      eventController.clear();
-      markController.clear();
-      yearController.clear();
-      meetController.clear();
-    });
-  }
+//   final _itemSet = <Item>{};
 
-  void _handleEventEdit(Event event) {
-    setState(() {
-      sprints.remove(event);
-      _EventInfoPopupForm(context);
-    });
-  }
+//   void _handleTrackItem(event, mark, year, meet) {
+//     setState(() {
+//       Event _event = Event(event: event, mark: mark, year: year, meet: meet);
+//       sprints.insert(0, _event);
+//       eventController.clear();
+//       markController.clear();
+//       yearController.clear();
+//       meetController.clear();
+//     });
+//   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          title: const Text('Distance Personal Records'),
-        ),
-        // drawer code from https://rushabhshah065.medium.com/flutter-navigation-drawer-tab-layout-e74074c249ce
-        drawer: Drawer(
-          child: ListView(
-            children: [
-              DrawerHeader(
-                decoration: BoxDecoration(color: Colors.green),
-                child: Text(
-                  "Type of Event",
-                  textAlign: TextAlign.justify,
-                  textScaleFactor: 2.0,
-                ),
-              ),
-              ListTile(
-                  title: Text("Sprints"),
-                  onTap: () {
-                    Navigator.push(context,
-                        MaterialPageRoute(builder: (context) {
-                      return const TrackList(title: 'Sprints');
-                    }));
-                  }),
-              ListTile(
-                title: Text("Distance"),
-                onTap: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return const SecondPage(title: 'Distance');
-                  }));
-                },
-              ),
-            ],
-          ),
-        ),
-        body: ListView(
-          padding: const EdgeInsets.symmetric(vertical: 8.0),
-          children: distance.map((item) {
-            return EventItem(
-              event: item,
-              eventEdit: _handleEventEdit,
-            );
-          }).toList(),
-        ),
-        floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.add),
-            onPressed: () {
-              _EventInfoPopupForm(context);
-            }));
-  }
-}
+//   void _handleEventEdit(Event event) {
+//     setState(() {
+//       sprints.remove(event);
+//       _EventInfoPopupForm(context);
+//     });
+//   }
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//         appBar: AppBar(
+//           title: const Text('Distance Personal Records'),
+//         ),
+//         // drawer code from https://rushabhshah065.medium.com/flutter-navigation-drawer-tab-layout-e74074c249ce
+//         drawer: Drawer(
+//           child: ListView(
+//             children: [
+//               DrawerHeader(
+//                 decoration: BoxDecoration(color: Colors.green),
+//                 child: Text(
+//                   "Type of Event",
+//                   textAlign: TextAlign.justify,
+//                   textScaleFactor: 2.0,
+//                 ),
+//               ),
+//               ListTile(
+//                   title: Text("Sprints"),
+//                   onTap: () {
+//                     Navigator.push(context,
+//                         MaterialPageRoute(builder: (context) {
+//                       return const TrackList(title: 'Sprints');
+//                     }));
+//                   }),
+//               ListTile(
+//                 title: Text("Distance"),
+//                 onTap: () {
+//                   Navigator.push(context, MaterialPageRoute(builder: (context) {
+//                     return const SecondPage(title: 'Distance');
+//                   }));
+//                 },
+//               ),
+//             ],
+//           ),
+//         ),
+//         body: ListView(
+//           padding: const EdgeInsets.symmetric(vertical: 8.0),
+//           children: distance.map((item) {
+//             return EventItem(
+//               event: item,
+//               eventEdit: _handleEventEdit,
+//             );
+//           }).toList(),
+//         ),
+//         floatingActionButton: FloatingActionButton(
+//             child: const Icon(Icons.add),
+//             onPressed: () {
+//               _EventInfoPopupForm(context);
+//             }));
+//   }
+// }
 
 void main() {
   runApp(const MaterialApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,8 @@ class _TrackListState extends State<TrackList> {
               width: 200,
               child: Column(
                 children: [
+                  // call FormFieldTemplate for each
+                  // will allow for easier universal use for future code iterations
                   FormFieldTemplate(
                       controller: eventController,
                       decoration: 'Event',
@@ -128,6 +130,7 @@ class _TrackListState extends State<TrackList> {
     );
   }
 
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -185,6 +188,7 @@ class _TrackListState extends State<TrackList> {
   }
 }
 
+// standard template for FormFields when adding events
 class FormFieldTemplate extends StatelessWidget {
   const FormFieldTemplate(
       {super.key,
@@ -192,6 +196,7 @@ class FormFieldTemplate extends StatelessWidget {
       required this.decoration,
       required this.formkey});
 
+  // key for field, controller, and string decoration
   final String formkey;
   final TextEditingController controller;
   final String decoration;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -185,6 +185,61 @@ class _TrackListState extends State<TrackList> {
   }
 }
 
+class FormFieldTemplate extends StatelessWidget {
+  const FormFieldTemplate(
+      {super.key,
+      required this.controller,
+      required this.decoration,
+      required this.formkey});
+
+  final String formkey;
+  final TextEditingController controller;
+  final String decoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      key: Key(formkey),
+      controller: controller,
+      decoration: InputDecoration(hintText: decoration),
+    );
+  }
+}
+
+// widget for listing the events as a List Tile within navigator
+class ListEvents extends StatelessWidget {
+  const ListEvents({Key? key, required this.title}) : super(key: key);
+
+  // passes title to determine type of list to display
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) {
+              return TrackList(title: title);
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+void main() {
+  runApp(const MaterialApp(
+    title: 'Sprint PRs',
+    home: TrackList(
+      title: 'Sprint PR',
+    ),
+  ));
+}
+
 // UNNEEDED SECOND PAGE CODE (APP ONLY USES TRACKLIST STATEFUL WIDGET NOW)
 
 // class SecondPage extends StatefulWidget {
@@ -331,58 +386,3 @@ class _TrackListState extends State<TrackList> {
 //             }));
 //   }
 // }
-
-class FormFieldTemplate extends StatelessWidget {
-  const FormFieldTemplate(
-      {super.key,
-      required this.controller,
-      required this.decoration,
-      required this.formkey});
-
-  final String formkey;
-  final TextEditingController controller;
-  final String decoration;
-
-  @override
-  Widget build(BuildContext context) {
-    return TextFormField(
-      key: Key(formkey),
-      controller: controller,
-      decoration: InputDecoration(hintText: decoration),
-    );
-  }
-}
-
-// widget for listing the events as a List Tile within navigator
-class ListEvents extends StatelessWidget {
-  const ListEvents({Key? key, required this.title}) : super(key: key);
-
-  // passes title to determine type of list to display
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(title),
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) {
-              return TrackList(title: title);
-            },
-          ),
-        );
-      },
-    );
-  }
-}
-
-void main() {
-  runApp(const MaterialApp(
-    title: 'Sprint PRs',
-    home: TrackList(
-      title: 'Sprint PR',
-    ),
-  ));
-}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,26 +40,22 @@ class _TrackListState extends State<TrackList> {
               width: 200,
               child: Column(
                 children: [
-                  TextFormField(
-                    key: const Key("EventField"),
-                    controller: eventController,
-                    decoration: InputDecoration(hintText: 'Event'),
-                  ),
-                  TextFormField(
-                    key: const Key("MarkField"),
-                    controller: markController,
-                    decoration: InputDecoration(hintText: 'Mark'),
-                  ),
-                  TextFormField(
-                    key: const Key("YearField"),
-                    controller: yearController,
-                    decoration: InputDecoration(hintText: 'Year'),
-                  ),
-                  TextFormField(
-                    key: const Key("MeetField"),
-                    controller: meetController,
-                    decoration: InputDecoration(hintText: 'Meet'),
-                  ),
+                  FormFieldTemplate(
+                      controller: eventController,
+                      decoration: 'Event',
+                      formkey: "EventField"),
+                  FormFieldTemplate(
+                      controller: markController,
+                      decoration: 'Mark',
+                      formkey: "MarkField"),
+                  FormFieldTemplate(
+                      controller: yearController,
+                      decoration: 'Year',
+                      formkey: "YearField"),
+                  FormFieldTemplate(
+                      controller: meetController,
+                      decoration: 'Meet',
+                      formkey: "MeetField"),
                 ],
               ),
             ),
@@ -97,11 +93,15 @@ class _TrackListState extends State<TrackList> {
         // renamed to newEvent to make clearer
         Event newEvent =
             Event(event: event, mark: mark, year: year, meet: meet);
+        // if widget title is sprints then insert event in sprints
         if (getTitle() == 'Sprints') {
           sprints.insert(0, newEvent);
-        } else {
+        }
+        // otherwise insert into distances
+        else {
           distances.insert(0, newEvent);
         }
+        // clear all controllers
         eventController.clear();
         markController.clear();
         yearController.clear();
@@ -122,7 +122,7 @@ class _TrackListState extends State<TrackList> {
         else {
           distances.remove(event);
         }
-        // commented out given it shows a deleted event
+        // commented out given it shows a deleted event's information
         // _EventInfoPopupForm(context);
       },
     );
@@ -332,9 +332,32 @@ class _TrackListState extends State<TrackList> {
 //   }
 // }
 
+class FormFieldTemplate extends StatelessWidget {
+  const FormFieldTemplate(
+      {super.key,
+      required this.controller,
+      required this.decoration,
+      required this.formkey});
+
+  final String formkey;
+  final TextEditingController controller;
+  final String decoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      key: Key(formkey),
+      controller: controller,
+      decoration: InputDecoration(hintText: decoration),
+    );
+  }
+}
+
 // widget for listing the events as a List Tile within navigator
 class ListEvents extends StatelessWidget {
   const ListEvents({Key? key, required this.title}) : super(key: key);
+
+  // passes title to determine type of list to display
   final String title;
 
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,7 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:to_dont_list/event_items.dart';
 
 import 'package:to_dont_list/main.dart';
-import 'package:to_dont_list/to_do_items.dart';
+
+// unneeded import
+// import 'package:to_dont_list/to_do_items.dart';
 
 void main() {
   // test('Item abbreviation should be first letter', () {


### PR DESCRIPTION
Addressing Issue #1 - Abstract the creation of two pages
- Dropped SecondPage class - only using TrackList class for both pages (left SecondPage class in code commented out for reference)
- Created Widget for FormFields to give a standard template that can be changed once rather than in 4 different places
- Created ListTile navigator Widget for moving between screens
- Dropped unneeded imports and added new comments for all additions
- All unit tests still work under new design